### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ https://www.dropbox.com/s/tvmdhre4ra8l41p/sample-debug-unaligned.apk
 
 Installing
 ---------------
-###Gradle
+### Gradle
 Add the following gradle dependency exchanging `x.x.x` for the latest release.
 ```groovy
 dependencies {


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
